### PR TITLE
README: Additional context and Go syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Appengine
 
-Implements appengine Log interface
+An [appengine/log][appengine] implemention of `log.Logger`][Logger].
+For more on the interface and other implementations, see [the log README][log].
 
-```
+```go
 package main
 
 import (
@@ -16,3 +17,7 @@ func main {
 	l.Log("a log line")
 }
 ```
+
+[appengine]: https://cloud.google.com/appengine/docs/standard/go/logs/
+[Logger]: https://godoc.org/github.com/go-log/log#Logger
+[log]: https://github.com/go-log/log/blob/master/README.md


### PR DESCRIPTION
Linking to the interface project should help orient appengine consumers in the go-log ecosystem.